### PR TITLE
PoC: Add a fully static version of Skyview

### DIFF
--- a/bsky.ts
+++ b/bsky.ts
@@ -164,6 +164,48 @@ export async function collectFullThread(postUri: string) {
     };
 }
 
+export function applyViewType(thread: BskyThreadPost, viewType: ViewType): BskyThreadPost {
+    if (viewType == "embed") {
+        if (thread.post.record.text.includes("@skyview.social") && thread.post.record.text.includes("embed") && thread.parent) {
+            thread = thread.parent;
+        }
+        thread = { ...thread, replies: [] };
+    }
+
+    if (viewType == "unroll") {
+        const posts: BskyThreadPost[] = [];
+        posts.push(thread);
+        while (true) {
+            const post = posts[posts.length - 1];
+            if (post.replies) {
+                var replies = post.replies.slice();
+                replies.sort((a, b) => a.post.record.createdAt.localeCompare(b.post.record.createdAt));
+                const next = replies.find(
+                    (reply) =>
+                    reply.post.author.did == post.post.author.did &&
+                        !reply.post.record.text.includes("@skyview.social") &&
+                        !reply.post.record.text.includes("unroll")
+                );
+                if (!next) break;
+                posts.push(next);
+            } else {
+                break;
+            }
+        }
+        thread = { ...thread };
+        thread.replies = posts.length > 1 ? posts.slice(1, posts.length) : [];
+        thread.replies = thread.replies.map((reply) => ({ ...reply, replies: [] }));
+        if (thread.replies.length > 0) {
+            const lastPost = thread.replies[thread.replies.length - 1];
+            if (lastPost.post.record.text.includes("@skyview.social") && lastPost.post.record.text.includes("unroll")) {
+                thread.replies.pop();
+            }
+        }
+    }
+
+    return thread;
+}
+
 export async function loadThread(url: string, viewType: ViewType): Promise<{ thread: BskyThreadPost; originalUri: string | undefined } | string> {
     try {
         const tokens = url.replace("https://", "").split("/");
@@ -194,42 +236,8 @@ export async function loadThread(url: string, viewType: ViewType): Promise<{ thr
         if (!thread) {
             return "Sorry, couldn't load thread (invalid thread)";
         }
-        if (viewType == "embed") {
-            if (thread.post.record.text.includes("@skyview.social") && thread.post.record.text.includes("embed") && thread.parent) {
-                thread = thread.parent;
-            }
-            thread.replies = [];
-        }
 
-        if (viewType == "unroll") {
-            const posts: BskyThreadPost[] = [];
-            posts.push(thread);
-            while (true) {
-                const post = posts[posts.length - 1];
-                if (post.replies) {
-                    post.replies.sort((a, b) => a.post.record.createdAt.localeCompare(b.post.record.createdAt));
-                    const next = post.replies.find(
-                        (reply) =>
-                            reply.post.author.did == post.post.author.did &&
-                            !reply.post.record.text.includes("@skyview.social") &&
-                            !reply.post.record.text.includes("unroll")
-                    );
-                    if (!next) break;
-                    posts.push(next);
-                } else {
-                    break;
-                }
-            }
-            thread.replies = posts.length > 1 ? posts.slice(1, posts.length) : [];
-            thread.replies.forEach((reply) => (reply.replies = []));
-            if (thread.replies.length > 0) {
-                const lastPost = thread.replies[thread.replies.length - 1];
-                if (lastPost.post.record.text.includes("@skyview.social") && lastPost.post.record.text.includes("unroll")) {
-                    thread.replies.pop();
-                }
-            }
-        }
-
+        thread = applyViewType(thread, viewType);
         return { thread, originalUri };
     } catch (e) {
         return `Sorry, couldn't load thread (exception) ${(e as any).message ? "\n" + (e as any).message : ""}`;

--- a/embed.html
+++ b/embed.html
@@ -9,6 +9,6 @@
     </head>
     <body class="bg-black text-white w-full h-full">
         <skyview-app embed="true"></skyview-app>
+        <script src="build/index.js" async></script>
     </body>
-    <script src="build/index.js" async></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,6 @@
     <body class="dark:bg-black dark:text-white">
         <theme-toggle></theme-toggle>
         <skyview-app></skyview-app>
+        <script src="build/index.js" async></script>
     </body>
-    <script src="build/index.js" async></script>
 </html>

--- a/index.ts
+++ b/index.ts
@@ -259,6 +259,7 @@ class App extends LitElement {
     @state()
     error?: string;
 
+    @state()
     url: string | null = null;
 
     @state()
@@ -274,24 +275,38 @@ class App extends LitElement {
     @state()
     copiedCode = false;
 
+    @state()
     viewType: ViewType = "tree";
 
     @property()
     embed = false;
 
+    @property()
+    local = false;
+
     constructor() {
         super();
-        this.url = new URL(location.href).searchParams.get("url");
-        this.viewType = new URL(location.href).searchParams.get("viewtype") as ViewType;
+        this.decodeURL();
+    }
+
+    protected decodeURL(): void {
+        let searchParams = this.local
+            ? new URLSearchParams(location.hash.substring(1))
+            : new URL(location.href).searchParams;
+        this.url = searchParams.get("url");
+        this.viewType = searchParams.get("viewtype") as ViewType;
         if (!this.viewType) this.viewType = "tree";
     }
 
-    firstUpdate = true;
-    protected willUpdate(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
-        if (this.firstUpdate) {
-            if (this.embed) this.viewType = "embed";
+    protected willUpdate(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
+        if (changedProperties.has("local") && this.local) {
+            addEventListener("hashchange", (_event) => { this.decodeURL() });
+            this.decodeURL();
+        }
+        if (this.embed) this.viewType = "embed";
+        if (changedProperties.has("url")) {
+            this.thread = null;
             if (this.url) this.load();
-            this.firstUpdate = false;
         }
     }
 
@@ -499,13 +514,20 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
         </main>`;
     }
 
+    setParams(url: string, viewType: ViewType) {
+        const searchParams = new URLSearchParams();
+        searchParams.set("url", url);
+        searchParams.set("viewtype", viewType);
+        if (this.local)
+            location.hash = "#" + searchParams.toString();
+        else
+            location.searchParams = searchParams;
+    }
+
     viewPosts() {
         if (!this.urlElement) return;
 
-        const newUrl = new URL(location.href);
-        newUrl.searchParams.set("url", this.urlElement.value);
-        newUrl.searchParams.set("viewtype", "tree");
-        location.href = newUrl.href;
+        this.setParams(this.urlElement.value, "tree");
     }
 
     changeView() {
@@ -513,10 +535,7 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
         if (!el) return;
         if (!this.url) return;
 
-        const newUrl = new URL(location.href);
-        newUrl.searchParams.set("url", this.url!);
-        newUrl.searchParams.set("viewtype", el.selectedValue);
-        location.href = newUrl.href;
+        this.setParams(this.url!, el.selectedValue);
     }
 
     defaultAvatar = svg`<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="none" data-testid="userAvatarFallback"><circle cx="12" cy="12" r="12" fill="#0070ff"></circle><circle cx="12" cy="9.5" r="3.5" fill="#fff"></circle><path stroke-linecap="round" stroke-linejoin="round" fill="#fff" d="M 12.058 22.784 C 9.422 22.784 7.007 21.836 5.137 20.262 C 5.667 17.988 8.534 16.25 11.99 16.25 C 15.494 16.25 18.391 18.036 18.864 20.357 C 17.01 21.874 14.64 22.784 12.058 22.784 Z"></path></svg>`;

--- a/index.ts
+++ b/index.ts
@@ -202,7 +202,7 @@ const contentLoader = html`<div class="flex space-x-4 animate-pulse w-[80%] max-
 import sunIconSvg from "remixicon/icons/Weather/sun-line.svg";
 // @ts-ignore
 import moonIconSvg from "remixicon/icons/Weather/moon-line.svg";
-import { BskyAuthor, BskyExternalCard, BskyImage, BskyRecord, BskyThreadPost, ViewType, loadThread, processText } from "./bsky";
+import { BskyAuthor, BskyExternalCard, BskyImage, BskyRecord, BskyThreadPost, ViewType, loadThread, applyViewType, processText } from "./bsky";
 
 function icon(svg: string) {
     return html`<i class="flex w-[1.2m] h-[1.2em] border-white fill-primary">${unsafeHTML(svg)}</i>`;
@@ -267,6 +267,7 @@ class App extends LitElement {
 
     @state()
     thread?: BskyThreadPost;
+    threadTree?: BskyThreadPost;
     originalUri?: string;
 
     @state()
@@ -305,8 +306,13 @@ class App extends LitElement {
         }
         if (this.embed) this.viewType = "embed";
         if (changedProperties.has("url")) {
-            this.thread = null;
+            this.error = undefined;
+            this.thread = undefined;
+            this.threadTree = undefined;
             if (this.url) this.load();
+        }
+        if (changedProperties.has("viewType") && this.threadTree) {
+            this.thread = applyViewType(this.threadTree, this.viewType);
         }
     }
 
@@ -323,11 +329,12 @@ class App extends LitElement {
         this.loading = true;
         this.originalUri = undefined;
         try {
-            const result = await loadThread(this.url, this.viewType);
+            const result = await loadThread(this.url, "tree");
             if (typeof result == "string") {
                 this.error = result;
             } else {
-                this.thread = result.thread;
+                this.threadTree = result.thread;
+                this.thread = applyViewType(this.threadTree, this.viewType);
                 this.originalUri = result.originalUri;
             }
         } catch (e) {

--- a/index.ts
+++ b/index.ts
@@ -348,7 +348,7 @@ class App extends LitElement {
                                 >
                                     <pre>
 &lt;iframe
-src=&quot;${location.protocol}//${location.host}/embed.html?url=${this.url}&quot;
+src=&quot;${new URL('embed.html',location.href).href}?url=${this.url}&quot;
 style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
 &gt;&lt;/iframe&gt;</pre
                                     >
@@ -356,7 +356,7 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
                                         class="text-white bg-primary px-4 py-2 mt-2 rounded"
                                         @click=${() =>
                                             this.copyToClipboard(
-                                                `<iframe src="${location.protocol}//${location.host}/embed.html?url=${this.url}" style="border: none; outline: none; width: 400px; height: 600px;"></iframe>`,
+                                                `<iframe src="${new URL('embed.html',location.href).href}?url=${this.url}" style="border: none; outline: none; width: 400px; height: 600px;"></iframe>`,
                                                 "code"
                                             )}
                                     >
@@ -465,7 +465,7 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
                         essentially what Skyview does. Without needing a BlueSky account. Here is the
                         <a
                             class="text-primary"
-                            href="/?url=https%3A%2F%2Fbsky.app%2Fprofile%2Fbadlogic.bsky.social%2Fpost%2F3kbt22jdyuw2l"
+                            href="./?url=https%3A%2F%2Fbsky.app%2Fprofile%2Fbadlogic.bsky.social%2Fpost%2F3kbt22jdyuw2l"
                             target="_blank"
                             >same post viewed via Skyview</a
                         >.
@@ -480,7 +480,7 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
 
         return html`<main class="flex flex-col justify-between m-auto max-w-[728px] px-4 h-full">
             ${!this.embed || this.loading
-                ? html`<a class="text-2xl flex align-center justify-center text-primary font-bold text-center my-8" href="/"
+                ? html`<a class="text-2xl flex align-center justify-center text-primary font-bold text-center my-8" href="."
                       ><i class="w-[32px] h-[32px] inline-block fill-primary">${unsafeHTML(logoSvg)}</i><span class="ml-2">Skyview</span></a
                   >
                   <span class="text-sm text-center mb-12">Entertained? Consider donating to our <a class="text-primary" target="_blank" href="https://bsky.app/profile/badlogic.bsky.social/post/3lazjayqwfk2q">🇺🇦 charity</a></span>
@@ -492,7 +492,7 @@ style=&quot;border: none; outline: none; width: 400px; height: 600px&quot;
                 <a class="text-primary" href="https://bsky.app/profile/badlogic.bsky.social" target="_blank">Mario Zechner</a><br />
                 Kindly supported by <a class="text-primary" class="https://mediamask.io/">Mediamask</a>, the most amazing template engine for image
                 generation<br />
-                Logo by <a href="marknzeichn.at" class="text-primary">Jan Hax</a><br />
+                Logo by <a href="https://marknzeichn.com/" class="text-primary">Jan Hax</a><br />
                 No data is collected, not even your IP address.<br />
                 <a class="text-primary" href="https://github.com/badlogic/skyview" target="_blank">Source code</a>
             </div>

--- a/local.html
+++ b/local.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=1" />
+        <title>Local Skyview</title>
+        <link rel="stylesheet" href="build/index.css" />
+        <!-- meta -->
+    </head>
+    <body class="dark:bg-black dark:text-white">
+        <theme-toggle></theme-toggle>
+        <skyview-app local="true"></skyview-app>
+        <script src="build/index.js" async></script>
+    </body>
+</html>


### PR DESCRIPTION
The current version of Skyview makes a server request for each new thread fetched, undermining the promise that everything happens client side. The final patch of this series implements a fully local version of Skyview. It's a bit rough around the edges. Notes:

* Some functionality is lost, notably the change of page title. That could be added.
* Obviously, anchors will no longer work.
* There is zero discoverability for the added `local.html`.
* On the plus side, just changing the view no longer fetches the thread again.
* I *believe* that all the original functionality is preserved, but I didn't actually test it.

The other two patches are minor cleanups; feel free to cherry-pick or request a separate PR.